### PR TITLE
Bug fix: ringing alarm couldn't be dismissed from the main activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,19 @@ Tired of pressing the power button/swiping the screen every time an alarm rings?
 
 
 ## Salient features:
+1. Works offline.
 1. The alarm is handled by a service which has almost no dependency with the UI. So, even if your UI freezes, the alarm will ring and can be dismissed.
 1. Uses latest Android Room database for storing alarms.
 1. Inbuilt dark theme, even in phones that do not support it.
+1. Snooze your alarm as many times as you want with custom snooze options.
 
 ## How to use?
 Simply download the latest apk file, install it and you are all set!
+
+## Google Play:
+
+You can also download the app from [Google Play](https://play.google.com/store/apps/details?id=in.basulabs.shakealarmclock).
+
+## How to contribute?
+Please read the [guidelines for contributing](https://github.com/WrichikBasu/ShakeAlarmClock/blob/master/CONTRIBUTING.md).
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "in.basulabs.shakealarmclock"
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 7
-        versionName "1.2.4"
+        versionCode 8
+        versionName "1.2.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/in/basulabs/shakealarmclock/Activity_AlarmsList.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/Activity_AlarmsList.java
@@ -291,6 +291,9 @@ public class Activity_AlarmsList extends AppCompatActivity implements AlarmAdapt
 
 		int alarmID = viewModel.getAlarmId(alarmDatabase, hour, mins);
 
+		// Kill any foreground service based on this alarm:
+		ConstantsAndStatics.killServices(this, alarmID);
+
 		PendingIntent pendingIntent = PendingIntent.getBroadcast(Activity_AlarmsList.this, alarmID, intent,
 				PendingIntent.FLAG_NO_CREATE);
 
@@ -306,8 +309,6 @@ public class Activity_AlarmsList extends AppCompatActivity implements AlarmAdapt
 			viewModel.toggleAlarmState(alarmDatabase, hour, mins, 0);
 		}
 
-		// Kill any foreground service based on this alarm:
-		ConstantsAndStatics.killServices(this, alarmID);
 
 		ConstantsAndStatics.schedulePeriodicWork(this);
 	}
@@ -324,8 +325,12 @@ public class Activity_AlarmsList extends AppCompatActivity implements AlarmAdapt
 	private void toggleAlarmState(int hour, int mins, final int newAlarmState) {
 
 		if (newAlarmState == 0) {
+			ConstantsAndStatics.killServices(this, viewModel.getAlarmId(alarmDatabase, hour, mins));
+
 			deleteOrDeactivateAlarm(MODE_DEACTIVATE_ONLY, hour, mins);
 		} else {
+			ConstantsAndStatics.killServices(this, viewModel.getAlarmId(alarmDatabase, hour, mins));
+
 			addOrActivateAlarm(MODE_ACTIVATE_EXISTING_ALARM, viewModel.getAlarmEntity(alarmDatabase, hour, mins),
 					viewModel.getRepeatDays(alarmDatabase, hour, mins));
 		}

--- a/app/src/main/java/in/basulabs/shakealarmclock/Activity_IntentManager.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/Activity_IntentManager.java
@@ -129,16 +129,10 @@ public class Activity_IntentManager extends AppCompatActivity {
 
 			case AlarmClock.ACTION_DISMISS_ALARM:
 
-				if (Service_RingAlarm.isThisServiceRunning || Service_SnoozeAlarm.isThisServiceRunning) {
-					Intent intent1 = new Intent();
-					intent1.setAction(ConstantsAndStatics.ACTION_CANCEL_ALARM);
-					sendBroadcast(intent1);
-				} else {
-					Intent intent1 = new Intent(this, Activity_AlarmsList.class);
-					intent1.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-							.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-					startActivity(intent1);
-				}
+				Intent intent2 = new Intent(this, Activity_AlarmsList.class);
+				intent2.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+						.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+				startActivity(intent2);
 
 				break;
 

--- a/app/src/main/java/in/basulabs/shakealarmclock/Activity_RingtonePicker.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/Activity_RingtonePicker.java
@@ -176,8 +176,7 @@ public class Activity_RingtonePicker extends AppCompatActivity implements View.O
 				}
 
 				if (intent.hasExtra(ConstantsAndStatics.EXTRA_PLAY_RINGTONE)) {
-					playTone = Objects.requireNonNull(intent.getExtras())
-							.getBoolean(ConstantsAndStatics.EXTRA_PLAY_RINGTONE);
+					playTone = Objects.requireNonNull(intent.getExtras()).getBoolean(ConstantsAndStatics.EXTRA_PLAY_RINGTONE);
 				} else {
 					playTone = true;
 				}

--- a/app/src/main/java/in/basulabs/shakealarmclock/ConstantsAndStatics.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/ConstantsAndStatics.java
@@ -2,6 +2,7 @@ package in.basulabs.shakealarmclock;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Process;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
@@ -156,6 +157,8 @@ final class ConstantsAndStatics {
 
 	static final String ACTION_NEW_ALARM_FROM_INTENT =
 			"in.basulabs.shakealarmclock.ACTION_NEW_ALARM_FROM_INTENT";
+
+	static final String ACTION_STOP_IMMEDIATELY = "in.basulabs.shakealarmclock.STOP_IMMEDIATELY";
 
 	/**
 	 * Indicates whether {@link Activity_RingtonePicker} should play the ringtone when the user clicks on a {@link
@@ -367,14 +370,10 @@ final class ConstantsAndStatics {
 	//---------------------------------------------------------------------------------------------------------
 
 	static void killServices(Context context, int alarmID) {
-		if (Service_RingAlarm.isThisServiceRunning && Service_RingAlarm.alarmID == alarmID) {
-			Intent intent = new Intent(context, Service_RingAlarm.class);
-			context.stopService(intent);
-		}
-		if (Service_SnoozeAlarm.isThisServiceRunning && Service_SnoozeAlarm.alarmID == alarmID) {
-			Intent intent = new Intent(context, Service_SnoozeAlarm.class);
-			context.stopService(intent);
-		}
+		Intent intent = new Intent()
+				.putExtra(BUNDLE_KEY_ALARM_ID, alarmID)
+				.setAction(ACTION_STOP_IMMEDIATELY);
+		context.sendBroadcast(intent);
 	}
 
 	//---------------------------------------------------------------------------------------------------------

--- a/app/src/main/java/in/basulabs/shakealarmclock/Fragment_AlarmDetails_Main.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/Fragment_AlarmDetails_Main.java
@@ -329,7 +329,7 @@ public class Fragment_AlarmDetails_Main extends Fragment
 					.query(viewModel.getAlarmToneUri(), null, null, null, null)) {
 
 				try {
-					if (cursor != null && cursor.moveToFirst()) {
+					if (cursor != null && cursor.getCount() > 0 && cursor.moveToFirst()) {
 
 						int index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
 						if (index != - 1) {
@@ -363,35 +363,28 @@ public class Fragment_AlarmDetails_Main extends Fragment
 
 	@Override
 	public void onClick(View view) {
-		switch (view.getId()) {
-			case R.id.saveButton:
-				saveButtonClicked();
-				break;
-			case R.id.cancelButton:
-				listener.onCancelButtonClick();
-				break;
-			case R.id.repeatConstraintLayout:
-				listener.onRequestRepeatFragCreation();
-				break;
-			case R.id.snoozeConstraintLayout:
-				listener.onRequestSnoozeFragCreation();
-				break;
-			case R.id.alarmDateConstraintLayout:
-				listener.onRequestDatePickerFragCreation();
-				break;
-			case R.id.alarmToneConstraintLayout:
-				Intent intent = new Intent(requireContext(), Activity_RingtonePicker.class)
-						.setAction(RingtoneManager.ACTION_RINGTONE_PICKER)
-						.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_ALARM)
-						.putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, "Select alarm tone:")
-						.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, false)
-						.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true)
-						.putExtra(ConstantsAndStatics.EXTRA_PLAY_RINGTONE, false)
-						.putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI, Settings.System.DEFAULT_ALARM_ALERT_URI)
-						.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, viewModel.getAlarmToneUri());
-				startActivityForResult(intent, RINGTONE_REQUEST_CODE);
-				break;
 
+		if (view.getId() == R.id.saveButton){
+			saveButtonClicked();
+		} else if (view.getId() == R.id.cancelButton){
+			listener.onCancelButtonClick();
+		} else if (view.getId() == R.id.repeatConstraintLayout){
+			listener.onRequestRepeatFragCreation();
+		} else if (view.getId() == R.id.snoozeConstraintLayout){
+			listener.onRequestSnoozeFragCreation();
+		} else if (view.getId() == R.id.alarmDateConstraintLayout){
+			listener.onRequestDatePickerFragCreation();
+		} else if (view.getId() == R.id.alarmToneConstraintLayout){
+			Intent intent = new Intent(requireContext(), Activity_RingtonePicker.class)
+					.setAction(RingtoneManager.ACTION_RINGTONE_PICKER)
+					.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_ALARM)
+					.putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, "Select alarm tone:")
+					.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, false)
+					.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true)
+					.putExtra(ConstantsAndStatics.EXTRA_PLAY_RINGTONE, false)
+					.putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI, Settings.System.DEFAULT_ALARM_ALERT_URI)
+					.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, viewModel.getAlarmToneUri());
+			startActivityForResult(intent, RINGTONE_REQUEST_CODE);
 		}
 	}
 


### PR DESCRIPTION
Previously, the currently ringing alarm could not be dismissed by toggling the alarm state in the list of alarms. The cause of this bug was (again) misuse of static variables.