### PR TITLE
Multiple bugfixes

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -51,7 +51,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_14" default="false" project-jdk-name="14" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_14_PREVIEW" default="false" project-jdk-name="14" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "in.basulabs.shakealarmclock"
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 11
-        versionName "1.2.8"
+        versionCode 12
+        versionName "1.2.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/in/basulabs/shakealarmclock/Activity_RingAlarm.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/Activity_RingAlarm.java
@@ -27,7 +27,7 @@ public class Activity_RingAlarm extends AppCompatActivity implements View.OnClic
 
 	private SharedPreferences sharedPreferences;
 
-	private BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+	private final BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
 		@Override
 		public void onReceive(Context context, Intent intent) {
 			if (Objects.equals(intent.getAction(), ConstantsAndStatics.ACTION_DESTROY_RING_ALARM_ACTIVITY)) {
@@ -73,7 +73,7 @@ public class Activity_RingAlarm extends AppCompatActivity implements View.OnClic
 			alarmTimeTextView.setText(getResources().getString(R.string.time_24hour,
 					localTime.getHour(), localTime.getMinute()));
 		} else {
-			String amPm = localTime.getHour() <= 12 ? "AM" : "PM";
+			String amPm = localTime.getHour() < 12 ? "AM" : "PM";
 
 			if ((localTime.getHour() <= 12) && (localTime.getHour() > 0)) {
 


### PR DESCRIPTION
 - `Service_SnoozeAlarm` will now update the alarm notification every 2s. This is solely done so as to keep the service active.
 - The `CountdownTimer` in `Service_SnoozeAlarm` will be cancelled inside `onDestroy()`. This is done so that the timer is cancelled even if the service was stopped by `Context.stopService(Intent)`.
 - `Activity_IntentManager` will now handle `android.provider.AlarmClock.ACTION_DISMISS_ALARM` differently: If an alarm is ringing, it will simply broadcast `ConstantsAndStatics.ACTION_CANCEL_ALARM` to dismiss the alarm.
 - Fixed AM-PM bug in `Activity_RingAlarm`.