### PR TITLE
Bugfix: App crashing when alarm is snoozed

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -51,7 +51,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_14_PREVIEW" default="false" project-jdk-name="14" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_14" default="false" project-jdk-name="14" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -51,7 +51,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_14" default="false" project-jdk-name="14" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_14_PREVIEW" default="false" project-jdk-name="14" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "in.basulabs.shakealarmclock"
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 12
-        versionName "1.2.9"
+        versionCode 13
+        versionName "1.2.10"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/in/basulabs/shakealarmclock/Activity_RingAlarm.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/Activity_RingAlarm.java
@@ -145,8 +145,7 @@ public class Activity_RingAlarm extends AppCompatActivity implements View.OnClic
 
 	private void onPowerButtonPressed() {
 		Intent intent;
-		int powerBtnAction = sharedPreferences.getInt(ConstantsAndStatics.SHARED_PREF_KEY_DEFAULT_POWER_BTN_OPERATION,
-				ConstantsAndStatics.DISMISS);
+		int powerBtnAction = sharedPreferences.getInt(ConstantsAndStatics.SHARED_PREF_KEY_DEFAULT_POWER_BTN_OPERATION, ConstantsAndStatics.DISMISS);
 		if (powerBtnAction == ConstantsAndStatics.DISMISS) {
 			intent = new Intent(ConstantsAndStatics.ACTION_CANCEL_ALARM);
 			sendBroadcast(intent);

--- a/app/src/main/java/in/basulabs/shakealarmclock/Service_SnoozeAlarm.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/Service_SnoozeAlarm.java
@@ -60,6 +60,9 @@ public class Service_SnoozeAlarm extends Service {
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
 
+		notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+		assert notificationManager != null;
+
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
 			startForeground(NOTIFICATION_ID, buildSnoozeNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_NONE);
 		} else {
@@ -79,8 +82,6 @@ public class Service_SnoozeAlarm extends Service {
 		IntentFilter intentFilter = new IntentFilter();
 		intentFilter.addAction(ConstantsAndStatics.ACTION_CANCEL_ALARM);
 		registerReceiver(broadcastReceiver, intentFilter);
-
-		notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 
 		Service_SnoozeAlarm myInstance = this;
 
@@ -128,7 +129,6 @@ public class Service_SnoozeAlarm extends Service {
 			NotificationChannel channel = new NotificationChannel(Integer.toString(NOTIFICATION_ID), "in.basulabs.shakealarmclock Notifications", importance);
 			//NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 			channel.setSound(null, null);
-			assert notificationManager != null;
 			notificationManager.createNotificationChannel(channel);
 		}
 	}
@@ -155,8 +155,7 @@ public class Service_SnoozeAlarm extends Service {
 	//-----------------------------------------------------------------------------------------------------
 
 	private void updateNotification() {
-		Intent intent = new Intent()
-				.setAction(ConstantsAndStatics.ACTION_CANCEL_ALARM);
+		Intent intent = new Intent().setAction(ConstantsAndStatics.ACTION_CANCEL_ALARM);
 		PendingIntent contentPendingIntent = PendingIntent.getBroadcast(this, 5017, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
 		NotificationCompat.Builder builder = new NotificationCompat.Builder(this, Integer.toString(NOTIFICATION_ID))


### PR DESCRIPTION
From Google Play reports:
```java
java.lang.RuntimeException: 
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:3917)
  at android.app.ActivityThread.access$1700 (ActivityThread.java:237)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1823)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:7078)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:494)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:964)
Caused by: java.lang.NullPointerException: 
  at in.basulabs.shakealarmclock.Service_SnoozeAlarm.createNotificationChannel (Service_SnoozeAlarm.java:1)
  at in.basulabs.shakealarmclock.Service_SnoozeAlarm.buildSnoozeNotification (Service_SnoozeAlarm.java:1)
  at in.basulabs.shakealarmclock.Service_SnoozeAlarm.onStartCommand (Service_SnoozeAlarm.java:17)
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:3898)
  at android.app.ActivityThread.access$1700 (ActivityThread.java:237)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1823)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:7078)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:494)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:964)
```


Reason: `notificationManager` was not initialized before calling `createNotificationChannel()` in `Service_SnoozeAlarm`.