### PR TITLE
Another fix for Service_SnoozeAlarm being killed midway

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "in.basulabs.shakealarmclock"
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 13
-        versionName "1.2.10"
+        versionCode 14
+        versionName "1.2.11"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -36,12 +36,12 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.1'
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "androidx.work:work-runtime:2.4.0"
     implementation 'com.github.javiersantos:AppUpdater:2.7'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation "androidx.room:room-runtime:2.2.5"
     annotationProcessor "androidx.room:room-compiler:2.2.5"
     implementation 'androidx.cardview:cardview:1.0.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,15 +59,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.DATE_CHANGED" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.TIME_SET" />
-            </intent-filter>
         </receiver>
 
         <activity android:name=".Activity_AlarmsList"

--- a/app/src/main/java/in/basulabs/shakealarmclock/AlarmBroadcastReceiver.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/AlarmBroadcastReceiver.java
@@ -23,14 +23,12 @@ public class AlarmBroadcastReceiver extends BroadcastReceiver {
 					"in.basulabs.shakealarmclock::AlarmRingServiceWakelockTag");
 			wakeLock.acquire(60000);
 
-			Intent intent1 = new Intent(context, Service_RingAlarm.class);
-			intent1.putExtra(ConstantsAndStatics.BUNDLE_KEY_ALARM_DETAILS,
+			Intent intent1 = new Intent(context, Service_RingAlarm.class)
+					.putExtra(ConstantsAndStatics.BUNDLE_KEY_ALARM_DETAILS,
 					Objects.requireNonNull(intent.getExtras()).getBundle(ConstantsAndStatics.BUNDLE_KEY_ALARM_DETAILS));
 			ContextCompat.startForegroundService(context, intent1);
 
-		} else if (Objects.equals(intent.getAction(), Intent.ACTION_BOOT_COMPLETED)
-				|| intent.getAction().equals(Intent.ACTION_TIMEZONE_CHANGED)
-				|| intent.getAction().equals(Intent.ACTION_TIME_CHANGED)) {
+		} else if (Objects.equals(intent.getAction(), Intent.ACTION_BOOT_COMPLETED)) {
 
 			PowerManager powerManager = (PowerManager) context.getSystemService(POWER_SERVICE);
 			PowerManager.WakeLock wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,

--- a/app/src/main/java/in/basulabs/shakealarmclock/Service_SnoozeAlarm.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/Service_SnoozeAlarm.java
@@ -144,8 +144,8 @@ public class Service_SnoozeAlarm extends Service {
 		NotificationCompat.Builder builder = new NotificationCompat.Builder(this, Integer.toString(NOTIFICATION_ID))
 				.setContentTitle(getResources().getString(R.string.app_name))
 				.setContentText(getResources().getString(R.string.notifContent_snooze))
-				.setPriority(NotificationCompat.PRIORITY_HIGH)
-				.setCategory(NotificationCompat.CATEGORY_STATUS)
+				.setPriority(NotificationCompat.PRIORITY_MAX)
+				.setCategory(NotificationCompat.CATEGORY_ALARM)
 				.setSmallIcon(R.drawable.ic_notif)
 				.setContentIntent(contentPendingIntent);
 

--- a/app/src/main/java/in/basulabs/shakealarmclock/Worker_ActivateAlarms.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/Worker_ActivateAlarms.java
@@ -43,8 +43,7 @@ public class Worker_ActivateAlarms extends Worker {
 		if (Service_RingAlarm.isThisServiceRunning || Service_SnoozeAlarm.isThisServiceRunning) {
 			return Result.failure();
 		} else {
-			activateAlarmsIfInactive();
-			return Result.success();
+			return activateAlarmsIfInactive();
 		}
 	}
 
@@ -53,7 +52,7 @@ public class Worker_ActivateAlarms extends Worker {
 	/**
 	 * Activates the alarms that are ON, but inactive because {@link AlarmManager} has cancelled them for no reason.
 	 */
-	private void activateAlarmsIfInactive() {
+	private Result activateAlarmsIfInactive() {
 
 		final AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
 		final AlarmDatabase alarmDatabase = AlarmDatabase.getInstance(context);
@@ -131,10 +130,11 @@ public class Worker_ActivateAlarms extends Worker {
 				}
 
 				if ((stopExecuting && ! isStopped()) || Service_RingAlarm.isThisServiceRunning || Service_SnoozeAlarm.isThisServiceRunning) {
-					break;
+					return Result.failure();
 				}
 			}
 		}
+		return Result.success();
 	}
 
 	//----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Some devices are still reporting that the snooze service is being killed midway, even after e3843683. The behaviour is this: the service is killed, and an alarm is set on the next day (at same time) immediately.

To be honest, this is becoming frustrating.

Anyway, we have to find the places where the service is being killed, and then another alarm is being set. The only relevant place comes out to be `Service_UpdateAlarm`.

`Service_UpdateAlarm` is supposed to be started from `AlarmBroadcastReceiver` when the following broadcasts are made from the system:
- `Intent.ACTION_BOOT_COMPLETED`
- `Intent.ACTION_TIMEZONE_CHANGED`
- `Intent.ACTION_TIME_CHANGED`

A Google search revealed something very interesting: a person [reported](https://stackoverflow.com/q/16684132/8387076) that `Intent.ACTION_TIME_CHANGED` was being triggered many times without changing time manually. The [accepted answer](https://stackoverflow.com/a/21188949/8387076) states that this action is broadcasted many times if the device uses network provided time.

As an urgent fix, both `Intent.ACTION_TIME_CHANGED` and `Intent.ACTION_TIMEZONE_CHANGED` have been removed from the manifest entry of `AlarmBroadcastReceiver`. Hope this solves the issue temporarily.