### PR TITLE
Support for Direct Boot

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "in.basulabs.shakealarmclock"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 32
-        versionName "4.0.0"
+        versionCode 33
+        versionName "4.1.0-beta"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,6 +82,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             android:name=".backend.Service_SnoozeAlarm"
             android:enabled="true"
             android:exported="false"
+            android:directBootAware="true"
             android:foregroundServiceType="specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
@@ -94,6 +95,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             android:name=".backend.Service_RingAlarm"
             android:enabled="true"
             android:exported="false"
+            android:directBootAware="true"
             android:foregroundServiceType="specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
@@ -104,12 +106,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         <receiver
             android:name=".backend.AlarmBroadcastReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="true"
+            android:directBootAware="true">
             <intent-filter>
                 <action android:name="in.basulabs.shakealarmclock.DELIVER_ALARM" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 
@@ -166,6 +172,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             android:name=".backend.Service_SetAlarmsPostBoot"
             android:enabled="true"
             android:exported="true"
+            android:directBootAware="true"
             android:foregroundServiceType="specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"

--- a/app/src/main/java/in/basulabs/shakealarmclock/backend/AlarmBroadcastReceiver.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/backend/AlarmBroadcastReceiver.java
@@ -52,7 +52,8 @@ public class AlarmBroadcastReceiver extends BroadcastReceiver {
 						.getBundle(ConstantsAndStatics.BUNDLE_KEY_ALARM_DETAILS));
 			ContextCompat.startForegroundService(context, intent1);
 
-		} else if (Objects.equals(intent.getAction(), Intent.ACTION_BOOT_COMPLETED)) {
+		} else if (Objects.equals(intent.getAction(), Intent.ACTION_BOOT_COMPLETED) ||
+			Objects.equals(intent.getAction(), Intent.ACTION_LOCKED_BOOT_COMPLETED)) {
 
 			PowerManager powerManager = (PowerManager) context.getSystemService(
 				POWER_SERVICE);

--- a/app/src/main/java/in/basulabs/shakealarmclock/backend/AlarmDatabase.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/backend/AlarmDatabase.java
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package in.basulabs.shakealarmclock.backend;
 
 import android.content.Context;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.room.Database;
@@ -31,9 +32,6 @@ import androidx.sqlite.db.SupportSQLiteDatabase;
 @TypeConverters({Convertors.class})
 public abstract class AlarmDatabase extends RoomDatabase {
 
-	private static final String DATABASE_NAME
-		= "in_basulabs_shakeAlarmClock_AlarmDatabase";
-
 	private static AlarmDatabase instance;
 
 	static final Migration MIGRATION_1_2 = new Migration(1, 2) {
@@ -44,10 +42,15 @@ public abstract class AlarmDatabase extends RoomDatabase {
 		}
 	};
 
-	public static synchronized AlarmDatabase getInstance(Context context) {
+	public static synchronized AlarmDatabase getInstance(@NonNull Context context) {
+
 		if (instance == null) {
-			instance = Room.databaseBuilder(context.getApplicationContext(),
-					AlarmDatabase.class, DATABASE_NAME)
+
+			instance = Room.databaseBuilder(
+					Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+						? context.createDeviceProtectedStorageContext()
+						: context.getApplicationContext(),
+					AlarmDatabase.class, ConstantsAndStatics.DATABASE_NAME)
 				.addMigrations(MIGRATION_1_2)
 				.fallbackToDestructiveMigrationOnDowngrade()
 				.build();

--- a/app/src/main/java/in/basulabs/shakealarmclock/backend/ConstantsAndStatics.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/backend/ConstantsAndStatics.java
@@ -404,6 +404,12 @@ public final class ConstantsAndStatics {
 	public static final String WORK_TAG_ACTIVATE_ALARMS =
 		"in.basulabs.WORK_ACTIVATE_ALARMS";
 
+	public static final String DATABASE_NAME =
+		"in_basulabs_shakeAlarmClock_AlarmDatabase";
+
+	public static final String SHARED_PREF_KEY_DATABASE_MOVED =
+		"in.basulabs.shakealarmclock.DATABASE_MOVED";
+
 	//-----------------------------------------------------------------------------------
 
 	/**

--- a/app/src/main/java/in/basulabs/shakealarmclock/backend/ConstantsAndStatics.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/backend/ConstantsAndStatics.java
@@ -16,6 +16,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 package in.basulabs.shakealarmclock.backend;
 
+import static android.content.Context.MODE_PRIVATE;
 import static android.content.Context.POWER_SERVICE;
 import static android.content.Context.USER_SERVICE;
 import static android.content.res.Configuration.UI_MODE_NIGHT_MASK;
@@ -26,6 +27,7 @@ import android.app.AlarmManager;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.PowerManager;
@@ -764,6 +766,18 @@ public final class ConstantsAndStatics {
 			case UI_MODE_NIGHT_YES -> true;
 			default -> false;
 		};
+	}
+
+	@NonNull
+	public static SharedPreferences getSharedPref(@NonNull Context context) {
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			return context.createDeviceProtectedStorageContext()
+				.getSharedPreferences(SHARED_PREF_FILE_NAME, MODE_PRIVATE);
+		} else {
+			return context.getSharedPreferences(ConstantsAndStatics.SHARED_PREF_FILE_NAME,
+				MODE_PRIVATE);
+		}
 	}
 
 

--- a/app/src/main/java/in/basulabs/shakealarmclock/backend/Service_RingAlarm.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/backend/Service_RingAlarm.java
@@ -180,8 +180,7 @@ public class Service_RingAlarm extends Service implements SensorEventListener,
 
 		ConstantsAndStatics.cancelScheduledPeriodicWork(this);
 
-		sharedPreferences = getSharedPreferences(
-			ConstantsAndStatics.SHARED_PREF_FILE_NAME, MODE_PRIVATE);
+		sharedPreferences = ConstantsAndStatics.getSharedPref(this);
 
 		audioFocusController = new AudioFocusController.Builder(this)
 			.setAcceptsDelayedFocus(true)

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmDetails.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmDetails.java
@@ -105,7 +105,7 @@ public class Activity_AlarmDetails extends AppCompatActivity implements
 		actionBar.setDisplayHomeAsUpEnabled(true);
 
 		fragmentManager = getSupportFragmentManager();
-		sharedPreferences = getSharedPreferences(SHARED_PREF_FILE_NAME, MODE_PRIVATE);
+		sharedPreferences = ConstantsAndStatics.getSharedPref(this);
 		viewModel = new ViewModelProvider(this).get(ViewModel_AlarmDetails.class);
 
 		if (savedInstanceState == null) {

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmsList.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmsList.java
@@ -31,6 +31,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.text.format.DateFormat;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -106,11 +107,11 @@ public class Activity_AlarmsList extends AppCompatActivity implements
 		setContentView(R.layout.activity_alarmslist);
 		setSupportActionBar(findViewById(R.id.toolbar));
 
+		moveToDeviceProtectedStorage();
+
 		sharedPref = getSharedPreferences(ConstantsAndStatics.SHARED_PREF_FILE_NAME,
 			MODE_PRIVATE);
 		sharedPrefEditor = sharedPref.edit();
-
-		moveDatabase();
 
 		alarmDatabase = AlarmDatabase.getInstance(this);
 		viewModel = new ViewModelProvider(this).get(ViewModel_AlarmsList.class);
@@ -886,28 +887,23 @@ public class Activity_AlarmsList extends AppCompatActivity implements
 
 	}
 
-	private void moveDatabase(){
+	/**
+	 * Moves the database and the shared preferences file to device protected storage
+	 * in Android N and above to make the app Direct Boot compatible.
+	 */
+	private void moveToDeviceProtectedStorage(){
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
 
-			if (getDatabasePath(DATABASE_NAME).exists()) {
+			boolean var1 = createDeviceProtectedStorageContext().moveDatabaseFrom(
+				getApplicationContext(), DATABASE_NAME);
 
-				if (!sharedPref.getBoolean(
-					ConstantsAndStatics.SHARED_PREF_KEY_DATABASE_MOVED,
-					false)) {
+			boolean var2 =
+				createDeviceProtectedStorageContext().moveSharedPreferencesFrom(this,
+					ConstantsAndStatics.SHARED_PREF_FILE_NAME);
 
-					createDeviceProtectedStorageContext().moveDatabaseFrom(
-						getApplicationContext(), DATABASE_NAME);
-
-					sharedPrefEditor.putBoolean(
-							ConstantsAndStatics.SHARED_PREF_KEY_DATABASE_MOVED,	true)
-						.commit();
-
-					//todo remove:
-					Toast.makeText(this, "Moved database.", Toast.LENGTH_LONG).show();
-				}
-
-			}
+			Log.e(ConstantsAndStatics.DEBUG_TAG, "Database moved? " + var1);
+			Log.e(ConstantsAndStatics.DEBUG_TAG, "Shared Pref moved? " + var2);
 		}
 
 	}

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmsList.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmsList.java
@@ -109,8 +109,7 @@ public class Activity_AlarmsList extends AppCompatActivity implements
 
 		moveToDeviceProtectedStorage();
 
-		sharedPref = getSharedPreferences(ConstantsAndStatics.SHARED_PREF_FILE_NAME,
-			MODE_PRIVATE);
+		sharedPref = ConstantsAndStatics.getSharedPref(this);
 		sharedPrefEditor = sharedPref.edit();
 
 		alarmDatabase = AlarmDatabase.getInstance(this);
@@ -806,11 +805,12 @@ public class Activity_AlarmsList extends AppCompatActivity implements
 	@RequiresApi(api = Build.VERSION_CODES.O)
 	private void deleteNotifChannels() {
 
+		final Context context = this;
+
 		new Thread(() -> {
 
 			SharedPreferences sharedPref =
-				getSharedPreferences(ConstantsAndStatics.SHARED_PREF_FILE_NAME,
-					MODE_PRIVATE);
+				ConstantsAndStatics.getSharedPref(context);
 
 			if (!sharedPref.getBoolean(
 				ConstantsAndStatics.SHARED_PREF_KEY_NOTIF_CHANNELS_DELETED, false)) {

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmsList.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmsList.java
@@ -895,15 +895,11 @@ public class Activity_AlarmsList extends AppCompatActivity implements
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
 
-			boolean var1 = createDeviceProtectedStorageContext().moveDatabaseFrom(
+			createDeviceProtectedStorageContext().moveDatabaseFrom(
 				getApplicationContext(), DATABASE_NAME);
 
-			boolean var2 =
-				createDeviceProtectedStorageContext().moveSharedPreferencesFrom(this,
+			createDeviceProtectedStorageContext().moveSharedPreferencesFrom(this,
 					ConstantsAndStatics.SHARED_PREF_FILE_NAME);
-
-			Log.e(ConstantsAndStatics.DEBUG_TAG, "Database moved? " + var1);
-			Log.e(ConstantsAndStatics.DEBUG_TAG, "Shared Pref moved? " + var2);
 		}
 
 	}

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_IntentManager.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_IntentManager.java
@@ -168,8 +168,7 @@ public class Activity_IntentManager extends AppCompatActivity {
 
 	private void setAlarm() {
 
-		SharedPreferences sharedPreferences = getSharedPreferences(SHARED_PREF_FILE_NAME,
-			MODE_PRIVATE);
+		SharedPreferences sharedPreferences = ConstantsAndStatics.getSharedPref(this);
 
 		///////////////////////////////////////////////
 		// Retrieve all data passed with intent:

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_ListReqPerm.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_ListReqPerm.java
@@ -72,8 +72,7 @@ public class Activity_ListReqPerm extends AppCompatActivity implements
 
 		Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
 
-		sharedPreferences = getSharedPreferences(
-			ConstantsAndStatics.SHARED_PREF_FILE_NAME, MODE_PRIVATE);
+		sharedPreferences = ConstantsAndStatics.getSharedPref(this);
 
 		viewModel = new ViewModelProvider(this).get(ViewModel_ListReqPerm.class);
 

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_ListReqPerm.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_ListReqPerm.java
@@ -15,7 +15,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.provider.Settings;
-import android.util.Log;
 import android.view.MenuItem;
 import android.widget.Toast;
 
@@ -92,9 +91,6 @@ public class Activity_ListReqPerm extends AppCompatActivity implements
 
 		reqPermsLauncher = registerForActivityResult(
 			new ActivityResultContracts.RequestPermission(), isGranted -> {
-
-				Log.println(Log.ERROR, getClass().getSimpleName(),
-					"Current permission = " + viewModel.getCurrentPermission());
 
 				if (viewModel.getCurrentPermission() != null) {
 					if (isGranted) {
@@ -199,9 +195,6 @@ public class Activity_ListReqPerm extends AppCompatActivity implements
 		viewModel.incrementTimesPermRequested(sharedPreferences,
 			permission.androidString());
 
-		Log.println(Log.ERROR, getClass().getSimpleName(),
-			"Set current permission = " + viewModel.getCurrentPermission());
-
 		int numberOfTimesRequested = viewModel.getTimesPermRequested(sharedPreferences,
 			permission.androidString());
 
@@ -247,7 +240,6 @@ public class Activity_ListReqPerm extends AppCompatActivity implements
 	}
 
 	private void observePermsQueue(ArrayList<Permission> permsQueue) {
-		Log.e(getClass().getSimpleName(), "Queue: " + permsQueue.toString());
 		if (permsQueue.isEmpty()) {
 			this.onBackPressed();
 		}

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_Settings.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_Settings.java
@@ -797,8 +797,6 @@ public class Activity_Settings extends AppCompatActivity implements
 
 		} else if (seekBar.getId() == R.id.shakeSensitivitySeekBar) {
 
-			Log.e(getClass().getSimpleName(),
-				"Sensitivity value = " + getSensitivityValue(seekBar.getProgress()));
 			prefEditor.remove(ConstantsAndStatics.SHARED_PREF_KEY_SHAKE_SENSITIVITY)
 				.putFloat(ConstantsAndStatics.SHARED_PREF_KEY_SHAKE_SENSITIVITY,
 					getSensitivityValue(seekBar.getProgress()))

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_Settings.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_Settings.java
@@ -125,8 +125,7 @@ public class Activity_Settings extends AppCompatActivity implements
 		//////////////////////////////////////////////////
 		// Get SharedPreferences and its editor:
 		/////////////////////////////////////////////////
-		sharedPreferences = getSharedPreferences(
-			ConstantsAndStatics.SHARED_PREF_FILE_NAME, MODE_PRIVATE);
+		sharedPreferences = ConstantsAndStatics.getSharedPref(this);
 		prefEditor = sharedPreferences.edit();
 
 		/////////////////////////////////////////////////

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Fragment_AlarmDetails_Main.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Fragment_AlarmDetails_Main.java
@@ -617,9 +617,7 @@ public class Fragment_AlarmDetails_Main extends Fragment implements View.OnClick
 	 * Handles {@code saveButton} clicks.
 	 */
 	private void saveButtonClicked() {
-		SharedPreferences sharedPreferences = requireContext()
-			.getSharedPreferences(ConstantsAndStatics.SHARED_PREF_FILE_NAME,
-				Context.MODE_PRIVATE);
+		SharedPreferences sharedPreferences = ConstantsAndStatics.getSharedPref(requireContext());
 
 		if (sharedPreferences.getBoolean(
 			ConstantsAndStatics.SHARED_PREF_KEY_AUTO_SET_TONE, true)) {


### PR DESCRIPTION
Main points to be noted:
- The database and the `SharedPreferences` file have to be moved to device protected storage. Moving the `SharedPreferences` file is necessary because it is accessed in `Service_RingAlarm`.
- Always access `SharedPreferences` and the database via device protected storage context after moving them.
- Do NOT access anything related to WorkManager in Direct Boot state because the `androidx.work.workdb` is accessible only when user has unlocked the device.

Closes #67.
Fixes #68.