### PR TITLE
Removed ACCESS_NETWORK_STATE perms

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
 Copyright (C) 2024  Wrichik Basu (basulabs.developer@gmail.com)
 
 This program is free software: you can redistribute it and/or modify
@@ -36,6 +37,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
+    <uses-permission
+        android:name="android.permission.ACCESS_NETWORK_STATE"
+        tools:node="remove" />
 
     <uses-feature
         android:name="android.hardware.audio.output"


### PR DESCRIPTION
This permission was being requested by `androidx.work`, as found in the [manifest merger report](https://stackoverflow.com/a/45831463/8387076):

```
uses-permission#android.permission.ACCESS_NETWORK_STATE
ADDED from [androidx.work:work-runtime:2.8.1]
```

 The app does not put a constraint regarding network state while scheduling periodic work, so this permission is not required.

Big thanks to @IzzySoft for helping me out on this one in #72 (specifically [this post](https://github.com/WrichikBasu/ShakeAlarmClock/discussions/72#discussioncomment-8576934)). :smile: 

For future reference: https://developermemos.com/posts/removing-unwanted-manifest-permissions