### PR TITLE
Major upgrade to meet latest Android SDK 36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .externalNativeBuild
 .cxx
 app/release/
+gradle/gradle-daemon-jvm.properties

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Tired of pressing the power button/swiping the screen every time an alarm rings?
 
 
 ## How to contribute?
-### Bug reports:
+### Bug reports
 Please create an issue with as much details as possible. Also look at the [guidelines](https://github.com/WrichikBasu/ShakeAlarmClock/blob/master/CONTRIBUTING.md#guidelines-for-creating-an-issue) for creating an issue.
 
-### Ideas/Feature Requests:
+### Ideas/Feature Requests
 Ideas for improvement and feature requests are always welcome. Please post them in the [Feature requests](https://github.com/WrichikBasu/ShakeAlarmClock/discussions/categories/feature-requests) category under Discussions.
 
-### Questions:
+### Questions
 We will try to answer all questions and help you in using this app. Please post your questions in the [Q&A category](https://github.com/WrichikBasu/ShakeAlarmClock/discussions/categories/q-a) under Discussions.
 
-### Forking and Pull Requests:
+### Forking and Pull Requests
 I appreciate people forking this repository and putting in their bit to improve it. Please follow the [guidelines](https://github.com/WrichikBasu/ShakeAlarmClock/blob/master/CONTRIBUTING.md#guidelines-for-forking-and-creating-pull-requests) for forking and creating pull requests.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,12 +20,12 @@ apply plugin: 'com.android.application'
 android {
     namespace 'in.basulabs.shakealarmclock'
 
-    compileSdk 35
+    compileSdk = 36 // https://stackoverflow.com/a/79737057/8387076
 
     defaultConfig {
         applicationId "in.basulabs.shakealarmclock"
-        minSdkVersion 21
-        targetSdkVersion 35
+        minSdkVersion 23
+        targetSdkVersion 36
         versionCode 36
         versionName "4.2.1"
 
@@ -35,8 +35,8 @@ android {
     compileOptions {
         coreLibraryDesugaringEnabled true
 
-        sourceCompatibility JavaVersion.VERSION_22
-        targetCompatibility JavaVersion.VERSION_22
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {
@@ -64,22 +64,22 @@ android {
 dependencies {
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "androidx.work:work-runtime:2.10.0"
+    implementation "androidx.work:work-runtime:2.11.2"
     implementation 'com.github.WrichikBasu:AudioFocusController:3.0.1'
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
-    implementation "androidx.room:room-runtime:2.6.1"
-    annotationProcessor "androidx.room:room-compiler:2.6.1"
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    implementation "androidx.room:room-runtime:2.8.4"
+    annotationProcessor "androidx.room:room-compiler:2.8.4"
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.3.2'
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.recyclerview:recyclerview:1.4.0'
+    implementation 'com.google.android.material:material:1.13.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'com.github.cachapa:ExpandableLayout:2.9.2'
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.14.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,12 +20,12 @@ apply plugin: 'com.android.application'
 android {
     namespace 'in.basulabs.shakealarmclock'
 
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "in.basulabs.shakealarmclock"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 36
         versionName "4.2.1"
 
@@ -35,8 +35,8 @@ android {
     compileOptions {
         coreLibraryDesugaringEnabled true
 
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_22
+        targetCompatibility JavaVersion.VERSION_22
     }
 
     buildTypes {
@@ -66,20 +66,20 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "androidx.work:work-runtime:2.8.1"
+    implementation "androidx.work:work-runtime:2.10.0"
     implementation 'com.github.WrichikBasu:AudioFocusController:3.0.1'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation "androidx.room:room-runtime:2.5.2"
-    annotationProcessor "androidx.room:room-compiler:2.5.2"
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
+    implementation "androidx.room:room-runtime:2.6.1"
+    annotationProcessor "androidx.room:room-compiler:2.6.1"
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.3.1'
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'com.github.cachapa:ExpandableLayout:2.9.2'
     implementation 'com.google.code.gson:gson:2.10.1'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 
 }

--- a/app/src/main/java/in/basulabs/shakealarmclock/backend/AlarmBroadcastReceiver.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/backend/AlarmBroadcastReceiver.java
@@ -27,10 +27,6 @@ import androidx.core.content.ContextCompat;
 
 import java.util.Objects;
 
-import in.basulabs.shakealarmclock.backend.ConstantsAndStatics;
-import in.basulabs.shakealarmclock.backend.Service_RingAlarm;
-import in.basulabs.shakealarmclock.backend.Service_SetAlarmsPostBoot;
-
 public class AlarmBroadcastReceiver extends BroadcastReceiver {
 
 	@Override

--- a/app/src/main/java/in/basulabs/shakealarmclock/backend/AlarmDatabase.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/backend/AlarmDatabase.java
@@ -52,7 +52,7 @@ public abstract class AlarmDatabase extends RoomDatabase {
 						: context.getApplicationContext(),
 					AlarmDatabase.class, ConstantsAndStatics.DATABASE_NAME)
 				.addMigrations(MIGRATION_1_2)
-				.fallbackToDestructiveMigrationOnDowngrade()
+				.fallbackToDestructiveMigration(true)
 				.build();
 		}
 		return instance;

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmDetails.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmDetails.java
@@ -344,7 +344,7 @@ public class Activity_AlarmDetails extends AppCompatActivity implements
 
 	@Override
 	public void onBackPressed() {
-
+		super.onBackPressed();
 		if (fragmentManager.getBackStackEntryCount() > 1) {
 			fragmentManager.popBackStackImmediate();
 			whichFragment = FRAGMENT_MAIN;

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmDetails.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmDetails.java
@@ -37,7 +37,6 @@ import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.BUNDLE_KEY
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.BUNDLE_KEY_REPEAT_DAYS;
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.BUNDLE_KEY_SNOOZE_FREQUENCY;
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.BUNDLE_KEY_SNOOZE_TIME_IN_MINS;
-import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.SHARED_PREF_FILE_NAME;
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.SHARED_PREF_KEY_DEFAULT_ALARM_TONE_URI;
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.SHARED_PREF_KEY_DEFAULT_ALARM_VOLUME;
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.SHARED_PREF_KEY_DEFAULT_SNOOZE_FREQ;
@@ -52,6 +51,7 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.view.MenuItem;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -195,6 +195,14 @@ public class Activity_AlarmDetails extends AppCompatActivity implements
 		}
 
 		setActionBarTitle();
+
+		getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+			@Override
+			public void handleOnBackPressed() {
+				whenBackPressed();
+				finish();
+			}
+		});
 
 	}
 
@@ -342,9 +350,10 @@ public class Activity_AlarmDetails extends AppCompatActivity implements
 
 	//----------------------------------------------------------------------------------------------------
 
-	@Override
-	public void onBackPressed() {
-		super.onBackPressed();
+	/**
+	 * Handles the back button press.
+	 */
+	private void whenBackPressed() {
 		if (fragmentManager.getBackStackEntryCount() > 1) {
 			fragmentManager.popBackStackImmediate();
 			whichFragment = FRAGMENT_MAIN;
@@ -359,7 +368,7 @@ public class Activity_AlarmDetails extends AppCompatActivity implements
 	@Override
 	public boolean onOptionsItemSelected(@NonNull MenuItem item) {
 		if (item.getItemId() == android.R.id.home) {
-			onBackPressed();
+			whenBackPressed();
 			return true;
 		}
 		return super.onOptionsItemSelected(item);

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmsList.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_AlarmsList.java
@@ -31,7 +31,6 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.text.format.DateFormat;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_IntentManager.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_IntentManager.java
@@ -32,7 +32,6 @@ import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.BUNDLE_KEY
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.BUNDLE_KEY_ALARM_YEAR;
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.BUNDLE_KEY_IS_REPEAT_ON;
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.BUNDLE_KEY_REPEAT_DAYS;
-import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.SHARED_PREF_FILE_NAME;
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.SHARED_PREF_KEY_DEFAULT_ALARM_TONE_URI;
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.SHARED_PREF_KEY_DEFAULT_ALARM_VOLUME;
 import static in.basulabs.shakealarmclock.backend.ConstantsAndStatics.SHARED_PREF_KEY_DEFAULT_SNOOZE_FREQ;

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_ListReqPerm.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_ListReqPerm.java
@@ -247,6 +247,7 @@ public class Activity_ListReqPerm extends AppCompatActivity implements
 
 	@Override
 	public void onBackPressed() {
+		super.onBackPressed();
 		if (viewModel.areEssentialPermsPresent()) {
 			setResult(RESULT_CANCELED);
 			finish();

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_ListReqPerm.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_ListReqPerm.java
@@ -35,6 +35,7 @@ import android.provider.Settings;
 import android.view.MenuItem;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
@@ -120,6 +121,14 @@ public class Activity_ListReqPerm extends AppCompatActivity implements
 
 		viewModel.observePermsQueue().observe(this, this::observePermsQueue);
 
+		getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+			@Override
+			public void handleOnBackPressed() {
+				whenBackPressed();
+				finish();
+			}
+		});
+
 	}
 
 	@Override
@@ -190,7 +199,7 @@ public class Activity_ListReqPerm extends AppCompatActivity implements
 	@Override
 	public boolean onOptionsItemSelected(@NonNull MenuItem item) {
 		if (item.getItemId() == android.R.id.home) {
-			this.onBackPressed();
+			this.whenBackPressed();
 			return true;
 		}
 		return super.onOptionsItemSelected(item);
@@ -245,9 +254,8 @@ public class Activity_ListReqPerm extends AppCompatActivity implements
 		onPermissionDenied();
 	}
 
-	@Override
-	public void onBackPressed() {
-		super.onBackPressed();
+
+	private void whenBackPressed() {
 		if (viewModel.areEssentialPermsPresent()) {
 			setResult(RESULT_CANCELED);
 			finish();
@@ -259,7 +267,7 @@ public class Activity_ListReqPerm extends AppCompatActivity implements
 
 	private void observePermsQueue(ArrayList<Permission> permsQueue) {
 		if (permsQueue.isEmpty()) {
-			this.onBackPressed();
+			this.whenBackPressed();
 		}
 	}
 

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_RingtonePicker.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_RingtonePicker.java
@@ -379,7 +379,7 @@ public class Activity_RingtonePicker extends AppCompatActivity implements
 
 	@Override
 	public void onBackPressed() {
-
+		super.onBackPressed();
 		if (viewModel.getPickedUri() == null) {
 			if (viewModel.getShowSilent()) {
 				Intent intent = new Intent().putExtra(EXTRA_RINGTONE_PICKED_URI,

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_RingtonePicker.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_RingtonePicker.java
@@ -347,7 +347,7 @@ public class Activity_RingtonePicker extends AppCompatActivity implements
 
 		RadioButton radioButton = new RadioButton(this);
 		radioButton.setId(id);
-		radioButton.setTextColor(getResources().getColor(R.color.defaultLabelColor));
+		radioButton.setTextColor(ContextCompat.getColor(this, R.color.defaultLabelColor));
 		radioButton.setTextSize(TypedValue.COMPLEX_UNIT_SP, 17);
 		radioButton.setLayoutParams(params);
 		radioButton.setText(text);

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_RingtonePicker.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_RingtonePicker.java
@@ -51,6 +51,7 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
@@ -146,6 +147,14 @@ public class Activity_RingtonePicker extends AppCompatActivity implements
 						}
 					}
 				}).build();
+
+		getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+			@Override
+			public void handleOnBackPressed() {
+				whenBackPressed();
+				finish();
+			}
+		});
 	}
 
 	//----------------------------------------------------------------------------------------------------
@@ -351,7 +360,7 @@ public class Activity_RingtonePicker extends AppCompatActivity implements
 	@Override
 	public boolean onOptionsItemSelected(@NonNull MenuItem item) {
 		if (item.getItemId() == android.R.id.home) {
-			this.onBackPressed();
+			whenBackPressed();
 			return true;
 		}
 		return super.onOptionsItemSelected(item);
@@ -377,9 +386,8 @@ public class Activity_RingtonePicker extends AppCompatActivity implements
 
 	//----------------------------------------------------------------------------------------------------
 
-	@Override
-	public void onBackPressed() {
-		super.onBackPressed();
+
+	private void whenBackPressed() {
 		if (viewModel.getPickedUri() == null) {
 			if (viewModel.getShowSilent()) {
 				Intent intent = new Intent().putExtra(EXTRA_RINGTONE_PICKED_URI,

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_Settings.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_Settings.java
@@ -582,7 +582,7 @@ public class Activity_Settings extends AppCompatActivity implements
 	@Override
 	public boolean onOptionsItemSelected(@NonNull MenuItem item) {
 		if (item.getItemId() == android.R.id.home) {
-			onBackPressed();
+			getOnBackPressedDispatcher().onBackPressed();
 			return true;
 		}
 		return super.onOptionsItemSelected(item);

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_Settings.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Activity_Settings.java
@@ -36,7 +36,6 @@ import android.provider.OpenableColumns;
 import android.provider.Settings;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
@@ -57,6 +56,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 
 import net.cachapa.expandablelayout.ExpandableLayout;
@@ -696,14 +696,14 @@ public class Activity_Settings extends AppCompatActivity implements
 			snoozeIntvLabel.setEnabled(true);
 			snoozeFreqLabel.setEnabled(true);
 
-			snoozeIntvEditText.setTextColor(
-				getResources().getColor(R.color.defaultLabelColor));
+			snoozeIntvEditText.setTextColor(ContextCompat.getColor(this,
+					R.color.defaultLabelColor));
 			snoozeFreqEditText.setTextColor(
-				getResources().getColor(R.color.defaultLabelColor));
-			snoozeFreqLabel.setTextColor(
-				getResources().getColor(R.color.defaultLabelColor));
-			snoozeIntvLabel.setTextColor(
-				getResources().getColor(R.color.defaultLabelColor));
+					ContextCompat.getColor(this,	R.color.defaultLabelColor));
+			snoozeFreqLabel.setTextColor(ContextCompat.getColor(this,
+					R.color.defaultLabelColor));
+			snoozeIntvLabel.setTextColor(ContextCompat.getColor(this,
+					R.color.defaultLabelColor));
 
 		} else {
 
@@ -712,12 +712,14 @@ public class Activity_Settings extends AppCompatActivity implements
 			snoozeIntvLabel.setEnabled(false);
 			snoozeFreqLabel.setEnabled(false);
 
-			snoozeIntvEditText.setTextColor(
-				getResources().getColor(R.color.disabledColor));
-			snoozeFreqEditText.setTextColor(
-				getResources().getColor(R.color.disabledColor));
-			snoozeFreqLabel.setTextColor(getResources().getColor(R.color.disabledColor));
-			snoozeIntvLabel.setTextColor(getResources().getColor(R.color.disabledColor));
+			snoozeIntvEditText.setTextColor(ContextCompat.getColor(this,
+					R.color.disabledColor));
+			snoozeFreqEditText.setTextColor(ContextCompat.getColor(this,
+					R.color.disabledColor));
+			snoozeFreqLabel.setTextColor(ContextCompat.getColor(this,
+					R.color.disabledColor));
+			snoozeIntvLabel.setTextColor(ContextCompat.getColor(this,
+					R.color.disabledColor));
 		}
 	}
 

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Fragment_AlarmDetails_Main.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Fragment_AlarmDetails_Main.java
@@ -48,6 +48,7 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -174,15 +175,10 @@ public class Fragment_AlarmDetails_Main extends Fragment implements View.OnClick
 		// Initialise the GUI
 		///////////////////////////////////////////
 		timePicker.setIs24HourView(DateFormat.is24HourFormat(requireContext()));
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-			timePicker.setHour(viewModel.getAlarmDateTime().getHour());
-			timePicker.setMinute(viewModel.getAlarmDateTime().getMinute());
-		} else {
-			timePicker.setCurrentHour(viewModel.getAlarmDateTime().getHour());
-			timePicker.setCurrentMinute(viewModel.getAlarmDateTime().getMinute());
-		}
+        timePicker.setHour(viewModel.getAlarmDateTime().getHour());
+        timePicker.setMinute(viewModel.getAlarmDateTime().getMinute());
 
-		setDate();
+        setDate();
 
 		displayRepeatOptions();
 		displaySnoozeOptions();
@@ -228,8 +224,8 @@ public class Fragment_AlarmDetails_Main extends Fragment implements View.OnClick
 				} else {
 					amPmView = (ViewGroup) v2.getChildAt(3);
 				}
-				View.OnClickListener listener = v -> timePicker.setCurrentHour(
-					(timePicker.getCurrentHour() + 12) % 24);
+				View.OnClickListener listener = v -> timePicker.setHour(
+					(timePicker.getHour() + 12) % 24);
 
 				View am = amPmView.getChildAt(0);
 				View pm = amPmView.getChildAt(1);
@@ -270,12 +266,13 @@ public class Fragment_AlarmDetails_Main extends Fragment implements View.OnClick
 
 				alarmDateConstarintLayout.setEnabled(false);
 
-				alarmDateLabel.setTextColor(
-					getResources().getColor(R.color.disabledColor));
+				alarmDateLabel.setTextColor(ContextCompat.getColor(requireContext(),
+						R.color.disabledColor));
 				alarmDateLabel.setPaintFlags(
 					alarmDateLabel.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
 
-				alarmDateTV.setTextColor(getResources().getColor(R.color.disabledColor));
+				alarmDateTV.setTextColor(ContextCompat.getColor(requireContext(),
+						R.color.disabledColor));
 				alarmDateTV.setPaintFlags(
 					alarmDateLabel.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
 
@@ -283,13 +280,13 @@ public class Fragment_AlarmDetails_Main extends Fragment implements View.OnClick
 
 				alarmDateConstarintLayout.setEnabled(true);
 
-				alarmDateLabel.setTextColor(
-					getResources().getColor(R.color.defaultLabelColor));
+				alarmDateLabel.setTextColor(ContextCompat.getColor(requireContext(),
+						R.color.defaultLabelColor));
 				alarmDateLabel.setPaintFlags(
 					alarmDateLabel.getPaintFlags() & (~Paint.STRIKE_THRU_TEXT_FLAG));
 
-				alarmDateTV.setTextColor(
-					getResources().getColor(R.color.defaultLabelColor));
+				alarmDateTV.setTextColor(ContextCompat.getColor(requireContext(),
+						R.color.defaultLabelColor));
 				alarmDateTV.setPaintFlags(
 					alarmDateLabel.getPaintFlags() & (~Paint.STRIKE_THRU_TEXT_FLAG));
 			}
@@ -299,19 +296,20 @@ public class Fragment_AlarmDetails_Main extends Fragment implements View.OnClick
 
 			if (alarmType == ConstantsAndStatics.ALARM_TYPE_VIBRATE_ONLY) {
 
-				alarmVolumeLabel.setTextColor(
-					getResources().getColor(R.color.disabledColor));
+				alarmVolumeLabel.setTextColor(ContextCompat.getColor(requireContext(),
+						R.color.disabledColor));
 				alarmVolumeLabel.setPaintFlags(
 					alarmDateLabel.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
 
 				alarmVolumeSeekbar.setEnabled(false);
 
-				alarmToneLabel.setTextColor(
-					getResources().getColor(R.color.disabledColor));
+				alarmToneLabel.setTextColor(ContextCompat.getColor(requireContext(),
+						R.color.disabledColor));
 				alarmToneLabel.setPaintFlags(
 					alarmDateLabel.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
 
-				alarmToneTV.setTextColor(getResources().getColor(R.color.disabledColor));
+				alarmToneTV.setTextColor(ContextCompat.getColor(requireContext(),
+						R.color.disabledColor));
 				alarmToneTV.setPaintFlags(
 					alarmDateLabel.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
 
@@ -319,20 +317,20 @@ public class Fragment_AlarmDetails_Main extends Fragment implements View.OnClick
 
 			} else {
 
-				alarmVolumeLabel.setTextColor(
-					getResources().getColor(R.color.defaultLabelColor));
+				alarmVolumeLabel.setTextColor(ContextCompat.getColor(requireContext(),
+						R.color.defaultLabelColor));
 				alarmVolumeLabel.setPaintFlags(
 					alarmDateLabel.getPaintFlags() & (~Paint.STRIKE_THRU_TEXT_FLAG));
 
 				alarmVolumeSeekbar.setEnabled(true);
 
-				alarmToneLabel.setTextColor(
-					getResources().getColor(R.color.defaultLabelColor));
+				alarmToneLabel.setTextColor(ContextCompat.getColor(requireContext(),
+						R.color.defaultLabelColor));
 				alarmToneLabel.setPaintFlags(
 					alarmDateLabel.getPaintFlags() & (~Paint.STRIKE_THRU_TEXT_FLAG));
 
-				alarmToneTV.setTextColor(
-					getResources().getColor(R.color.defaultLabelColor));
+				alarmToneTV.setTextColor(ContextCompat.getColor(requireContext(),
+						R.color.defaultLabelColor));
 				alarmToneTV.setPaintFlags(
 					alarmDateLabel.getPaintFlags() & (~Paint.STRIKE_THRU_TEXT_FLAG));
 

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Fragment_AlarmDetails_Main.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Fragment_AlarmDetails_Main.java
@@ -43,6 +43,8 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.TimePicker;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.constraintlayout.widget.ConstraintLayout;
@@ -63,8 +65,6 @@ public class Fragment_AlarmDetails_Main extends Fragment implements View.OnClick
 	SeekBar.OnSeekBarChangeListener, TimePicker.OnTimeChangedListener,
 	AdapterView.OnItemSelectedListener {
 
-	private static final int RINGTONE_REQUEST_CODE = 5280;
-
 	private ViewModel_AlarmDetails viewModel;
 
 	private FragmentGUIListener listener;
@@ -73,7 +73,7 @@ public class Fragment_AlarmDetails_Main extends Fragment implements View.OnClick
 	private ImageView alarmVolumeImageView;
 	private boolean isSavedInstanceStateNull;
 
-	//----------------------------------------------------------------------------------------------------
+    //----------------------------------------------------------------------------------------------------
 
 	public interface FragmentGUIListener {
 
@@ -495,34 +495,27 @@ public class Fragment_AlarmDetails_Main extends Fragment implements View.OnClick
 					Settings.System.DEFAULT_ALARM_ALERT_URI)
 				.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI,
 					viewModel.getAlarmToneUri());
-			startActivityForResult(intent, RINGTONE_REQUEST_CODE);
+
+            ActivityResultLauncher<Intent> alarmToneActLauncher = registerForActivityResult(
+                    new ActivityResultContracts.StartActivityForResult(), (result) -> {
+
+                        if (result.getResultCode() == RESULT_OK) {
+
+                            Intent data = result.getData();
+                            assert data != null;
+                            Uri uri = Objects.requireNonNull(data.getExtras())
+                                    .getParcelable(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
+                            assert uri != null;
+                            viewModel.setAlarmToneUri(uri);
+                        }
+                        displayAlarmTone();
+                    });
+			alarmToneActLauncher.launch(intent);
 
 		} else if (view.getId() == R.id.alarmMessageConstraintLayout) {
 			listener.onRequestMessageFragCreation();
 		}
 	}
-
-	//----------------------------------------------------------------------------------------------------
-
-	@Override
-	public void onActivityResult(int requestCode, int resultCode,
-		@Nullable Intent data) {
-		super.onActivityResult(requestCode, resultCode, data);
-
-		if (requestCode == RINGTONE_REQUEST_CODE) {
-
-			if (resultCode == RESULT_OK) {
-
-				assert data != null;
-				Uri uri = Objects.requireNonNull(data.getExtras())
-					.getParcelable(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
-				assert uri != null;
-				viewModel.setAlarmToneUri(uri);
-			}
-		}
-		displayAlarmTone();
-	}
-
 
 	//----------------------------------------------------------------------------------------------------
 

--- a/app/src/main/java/in/basulabs/shakealarmclock/frontend/Fragment_AlarmDetails_RepeatOptions.java
+++ b/app/src/main/java/in/basulabs/shakealarmclock/frontend/Fragment_AlarmDetails_RepeatOptions.java
@@ -86,7 +86,7 @@ public class Fragment_AlarmDetails_RepeatOptions extends Fragment implements
 	//----------------------------------------------------------------------------------------------------
 
 	@Override
-	public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
+	public void onCheckedChanged(@NonNull CompoundButton compoundButton, boolean isChecked) {
 
 		CheckBox checkBox = (CheckBox) compoundButton;
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.1'
+        classpath 'com.android.tools.build:gradle:9.1.1'
     }
 }
 
@@ -24,5 +24,5 @@ allprojects {
 }
 
 tasks.register('clean', Delete) {
-    delete rootProject.buildDir
+    delete rootProject.layout.buildDirectory
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.6.1'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,13 @@ org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 03 10:07:37 IST 2023
+#Thu Dec 12 21:25:51 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Dec 12 21:25:51 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,5 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
 include ':app'
 rootProject.name = "Shake Alarm Clock"


### PR DESCRIPTION
- Most deprecated methods have been fixed to some extent.
- No support for Android Lollipop. Support limited to Android Marshmallow and above (SDK >= 23). This has been done to support newer versions of Android Room.
- `if`-clauses for Android Lollipop have not been removed.
- JDK has been downgraded to 17 for now.